### PR TITLE
Don't use margins for categories on mobile

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -1,8 +1,19 @@
-@import '~bulma';
+@import "~bulma";
+
 .navbar-item img {
   max-height: 4rem;
 }
 
 .custom-container {
   margin-top: 5rem;
+}
+
+@include desktop {
+  .desktop-ml-6 {
+    margin-left: 3rem;
+  }
+
+  .desktop-mt-6 {
+    margin-top: 3rem;
+  }
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -33,7 +33,7 @@
       <button class="p-2 add-semester-btn has-text-weight-bold" v-on:click="addSemester">+</button>
     </div>
   </div>
-  <div class="columns mt-6 ml-6">
+  <div class="columns desktop-ml-6 desktop-mt-6">
     <div class="column">
       <article>
         <h2 class="subtitle">Übersicht der ECTS Punkte</h2>


### PR DESCRIPTION
Gives the categories a bit more breathing room on mobile while leaving everything above 1024px as before.

Before:

![image](https://user-images.githubusercontent.com/7010698/154865631-67a661ad-715c-4d71-86a5-a97ec1b27f9d.png)

Afterwards:

![image](https://user-images.githubusercontent.com/7010698/154865646-c8162b17-338c-4212-ac7d-e4f24591d722.png)