### PR TITLE
Fix vue errors by using proper types for component bindings

### DIFF
--- a/src/components/Focus.vue
+++ b/src/components/Focus.vue
@@ -4,7 +4,6 @@
       @click="toggleFocus()"
       class="button is-fullwidth button-focus"
       :aria-expanded="isOpen"
-      :aria-controls="`collapse${_uid}`"
       :class="{'is-success': !filteredModules.length}"
     >
 
@@ -21,7 +20,7 @@
         </span>
       </div>
     </button>
-    <div v-show="isOpen" :id="`collapse${_uid}`" class="column is-full column-focus">
+    <div v-show="isOpen" class="column is-full column-focus">
       <div class="box box-focus">
             <p v-if="!filteredModules.length">
               Alle benötigten Module sind bestanden/geplant.

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -48,9 +48,9 @@
             </td>
             <td style="padding-top:8px">
               <BeautifulProgressIndicator
-              :required="category.required_ects"
-              :earned="category.earnedCredits"
-              :planned="category.plannedCredits"
+              :required=category.required_ects
+              :earned=category.earnedCredits
+              :planned=category.plannedCredits
               :color="category.color"
               ></BeautifulProgressIndicator>
             </td>
@@ -61,7 +61,7 @@
             </td>
             <td style="padding-top:8px">
               <BeautifulProgressIndicator
-              :required="180"
+              :required=180
               :earned="totalEarnedEcts"
               :planned="totalPlannedEcts"
               :color="`orange`"
@@ -176,7 +176,9 @@ export default {
       fetch(`${BASE_URL}${ROUTE_CATEGORIES}`)
         .then((response) => response.json())
         .then((categories) => {
-          this.categories = categories;
+          // make sure required_ects is a number
+          this.categories = categories
+            .map((c) => ({ ...c, required_ects: Number(c.required_ects) }));
         });
     },
     loadFocuses() {


### PR DESCRIPTION
Some comments:
- _uid was undefined anyways, so it was useless
- with `:` data binds in vue, don't use quotes for numbers, as vue converts those numbers into strings implicitly then
- the data provided in the json has required_ects as a string, so I ensured it's a number. Feel free to disagree with that, but it ejected a warning as it was used implicitly for a number property on the progress (required)